### PR TITLE
Using doc instead of pandas-doc for the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ install:
 
 script:
   - set -e
-  - cd pandas-docs
+  - cd docs
   - python make.py html
   - cd ..
   - if [[ "${TRAVIS_BRANCH}" == "master" ]]; then
-      doctr deploy . --built-docs pandas-docs/build/html/;
+      doctr deploy . --built-docs docs/build/html/;
     else
-      doctr deploy "pr-$TRAVIS_BRANCH" --built-docs pandas-docs/build/html/ --no-require-master;
+      doctr deploy "pr-$TRAVIS_BRANCH" --built-docs docs/build/html/ --no-require-master;
     fi
 
 


### PR DESCRIPTION
@jorisvandenbossche, @stijnvanhoey, if that's ok I'll make travis build the directory `doc` instead of `pandas-doc`. I'm making a script that performs the operations to change the theme, so besides working in this repo, then it can be applied to the pandas repo. This way we don't have complex merges if the documentation changes in the main repo, and here we have an old copy. And for that script to be simpler, I prefer to replicate the same structure as the pandas repo here (that's why the change `pandas-doc` by `doc`).

This change means that if you want to update your branches and have the build working, you should rename the directory there. 