### PR TITLE
Canonicalize CRAN links

### DIFF
--- a/pandas-docs/source/getting_started/comparison/comparison_with_r.rst
+++ b/pandas-docs/source/getting_started/comparison/comparison_with_r.rst
@@ -31,7 +31,7 @@ Quick Reference
 
 We'll start off with a quick reference guide pairing some common R
 operations using `dplyr
-<http://cran.r-project.org/web/packages/dplyr/index.html>`__ with
+<http://cran.r-project.org/package=dplyr>`__ with
 pandas equivalents.
 
 

--- a/pandas-docs/source/user_guide/visualization.rst
+++ b/pandas-docs/source/user_guide/visualization.rst
@@ -1026,7 +1026,7 @@ unit interval). The point in the plane, where our sample settles to (where the
 forces acting on our sample are at an equilibrium) is where a dot representing
 our sample will be drawn. Depending on which class that sample belongs it will
 be colored differently.
-See the R package `Radviz <https://cran.r-project.org/web/packages/Radviz/>`__
+See the R package `Radviz <https://cran.r-project.org/package=Radviz/>`__
 for more information.
 
 **Note**: The "Iris" dataset is available `here <https://raw.github.com/pandas-dev/pandas/master/pandas/tests/data/iris.csv>`__.

--- a/pandas-docs/source/whatsnew/v0.16.0.rst
+++ b/pandas-docs/source/whatsnew/v0.16.0.rst
@@ -43,7 +43,7 @@ DataFrame Assign
 ^^^^^^^^^^^^^^^^
 
 Inspired by `dplyr's
-<http://cran.rstudio.com/web/packages/dplyr/vignettes/introduction.html#mutate>`__ ``mutate`` verb, DataFrame has a new
+<http://cran.rstudio.com/package=dplyr/vignettes/introduction.html#mutate>`__ ``mutate`` verb, DataFrame has a new
 :meth:`~pandas.DataFrame.assign` method.
 The function signature for ``assign`` is simply ``**kwargs``. The keys
 are the column names for the new fields, and the values are either a value


### PR DESCRIPTION
[CRAN asks to use the  URL variant](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) when linking to packages ;-) This PR results from a semi-automatic search-and-replace script and implements their suggestion.
