### PR TITLE
Remove nav-tabs class from toc right sidebar

### DIFF
--- a/pandas-docs/source/_themes/bootstrap_docs_theme/docs-toc.html
+++ b/pandas-docs/source/_themes/bootstrap_docs_theme/docs-toc.html
@@ -1,7 +1,7 @@
 {% set page_toc = get_page_toc_object() %}
 
 <nav id="bd-toc-nav">
-    <ul class="nav nav-tabs section-nav flex-column" role="tablist">
+    <ul class="nav section-nav flex-column">
     {% for item in page_toc.children recursive %}
         <li class="toc-entry toc-h{{ loop.depth + 1 }}">
             <a href="{{ item.url }}" class="nav-item nav-link">{{ item.title }}</a>


### PR DESCRIPTION
The toc sidebar is not a tabbed interface, so should not have the `nav-tabs` class I think (https://getbootstrap.com/docs/4.3/components/navs/#tabs).

This fixes the strange bottom border.