### PR TITLE
Nowrap of first column HTML table for autosummary

### DIFF
--- a/pandas_sphinx_theme/static/sphinx-bootstrap.css_t
+++ b/pandas_sphinx_theme/static/sphinx-bootstrap.css_t
@@ -161,6 +161,15 @@ table td.data, table th.row_heading table th.col_heading {
     text-align: right;
 }
 
+/**
+ * Styling for autosummary tables
+ */
+
+/* The first column (with the signature) should not wrap */
+td:first-child {
+    white-space: nowrap;
+}
+
 
 /**
  * See also


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas-sphinx-theme/issues/16

By adding a `white-space: nowrap` for the first column, we avoid the ugly autosummary tables. Of course, it does it then for all tables (ideally sphinx would give a class for the autosummary tables that we could target, but this is currently not the case)