### PR TITLE
Control presence of local toc with :notoc: field list metadata

### DIFF
--- a/pandas-docs/source/getting_started/overview.rst
+++ b/pandas-docs/source/getting_started/overview.rst
@@ -1,3 +1,5 @@
+:notoc:
+
 .. _overview:
 
 {{ header }}

--- a/pandas-docs/source/index.rst.template
+++ b/pandas-docs/source/index.rst.template
@@ -1,3 +1,5 @@
+:notoc:
+
 .. pandas documentation master file, created by
 
 .. module:: pandas

--- a/pandas_sphinx_theme/layout.html
+++ b/pandas_sphinx_theme/layout.html
@@ -39,7 +39,7 @@
           </div>
           
           <div class="d-none d-xl-block col-xl-2 bd-toc">
-              {% if not pagename.endswith('index') and not '/api/' in pagename %}
+              {% if not (meta is not none and 'notoc' in meta) %}
                 {%- include "docs-toc.html" %}
               {% endif %}
             </div>


### PR DESCRIPTION
Addresses third item of https://github.com/pandas-dev/pandas-sphinx-theme/issues/36#issuecomment-547621601

cc @choldgraf