### PR TITLE
Fix parsing of multiple toctree directives on a single page / with a caption

### DIFF
--- a/pandas-docs/source/index.rst.template
+++ b/pandas-docs/source/index.rst.template
@@ -51,6 +51,12 @@ See the :ref:`overview` for more detail about what's in the library.
     whatsnew/index
 {% endif -%}
 
+.. toctree::
+    :maxdepth: 2
+    :caption: An extra caption. This item should be at the end of page nav (and duplicated)
+
+    development/index
+
 
 * :doc:`whatsnew/v0.25.0`
 * :doc:`install`

--- a/pandas_sphinx_theme/__init__.py
+++ b/pandas_sphinx_theme/__init__.py
@@ -64,7 +64,7 @@ def update_page_context(self, pagename, templatename, ctx, event_arg):
         return nav
 
     def get_page_toc_object():
-        """Return a lits of within-page TOC links that can be accessed from Jinja."""
+        """Return a list of within-page TOC links that can be accessed from Jinja."""
         self_toc = TocTree(self.env).get_toc_for(pagename, self)
 
         try:

--- a/pandas_sphinx_theme/__init__.py
+++ b/pandas_sphinx_theme/__init__.py
@@ -8,7 +8,7 @@ import os
 import sphinx.builders.html
 
 from .bootstrap_html_translator import BootstrapHTML5Translator
-
+import docutils
 
 __version__ = "0.0.1.dev0"
 
@@ -27,7 +27,7 @@ def convert_docutils_node(list_item, only_pages=False):
 
     if only_pages and '#' in url:
         return None
-        
+
     nav = {}
     nav["title"] = title
     nav["url"] = url
@@ -47,18 +47,24 @@ def update_page_context(self, pagename, templatename, ctx, event_arg):
     from sphinx.environment.adapters.toctree import TocTree
 
     def get_nav_object(**kwds):
+        """Return a list of nav links that can be accessed from Jinja."""
         toctree = TocTree(self.env).get_toctree_for(
             pagename, self, collapse=True, **kwds
         )
 
+        # Grab all TOC links from any toctrees on the page
+        toc_items = [item for child in toctree.children for item in child
+                     if isinstance(item, docutils.nodes.list_item)]
+
         nav = []
-        for child in toctree.children[0].children:
+        for child in toc_items:
             child_nav = convert_docutils_node(child, only_pages=True)
             nav.append(child_nav)
 
         return nav
 
     def get_page_toc_object():
+        """Return a lits of within-page TOC links that can be accessed from Jinja."""
         self_toc = TocTree(self.env).get_toc_for(pagename, self)
 
         try:


### PR DESCRIPTION
I believe this fixes two issues:

* In building the `nav` object, we now grab children from all `toctree` elements on the page
* In building the `nav` object, we now remove anything from the `toctree` children that is not a link to a page (e.g. we remove caption elements)

This makes it the theme grab pages across multiple TOC trees, and also makes TOC tree elements discoverable even if they have captions.

closes https://github.com/pandas-dev/pandas-sphinx-theme/issues/36  