### PR TITLE
adding a markdown page to demo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,8 @@ release = '0.0.1dev0'
 
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary'
+    'sphinx.ext.autosummary',
+    'recommonmark'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -57,3 +58,11 @@ html_logo = '_static/pandas.svg'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+
+# -- Auto-convert markdown pages to demo --------------------------------------
+import recommonmark
+from recommonmark.transform import AutoStructify
+
+def setup(app):
+    app.add_transform(AutoStructify)

--- a/docs/demo/index.rst
+++ b/docs/demo/index.rst
@@ -15,6 +15,7 @@ the left sidebar to see how various elements look on this theme.
     api
     demo
     lists_tables
+    markdown
 
 .. toctree::
     :maxdepth: 3

--- a/docs/demo/markdown.md
+++ b/docs/demo/markdown.md
@@ -1,0 +1,35 @@
+# Markdown pages
+
+Sphinx can also generate pages from Markdown, using the Recommonmark package.
+This page demonstrates that this is possible! Note that in order for your
+in-page table of contents to work properly, in-page Markdown headings (except for
+the title) should have at least two `#` symbols.
+
+## A markdown section
+
+This section was created with `## A markdown section` - note that this is ATX-style
+heading, which rST usually does not support. However, with recommonmark it is possible!
+
+## First top-level
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sed sapien et sem scelerisque bibendum sed eget velit. Duis ut ultricies enim, vitae ultricies neque. Proin in purus eget orci posuere consequat sit amet ac augue. Aliquam dolor turpis, ultricies ac dui vel, maximus eleifend enim. Suspendisse eleifend orci non lectus mattis, pharetra blandit eros feugiat. Maecenas sed orci eget orci pharetra posuere id vel enim. Aenean ac lobortis lorem. Sed malesuada urna non consectetur condimentum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+### First second-level
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sed sapien et sem scelerisque bibendum sed eget velit. Duis ut ultricies enim, vitae ultricies neque. Proin in purus eget orci posuere consequat sit amet ac augue. Aliquam dolor turpis, ultricies ac dui vel, maximus eleifend enim. Suspendisse eleifend orci non lectus mattis, pharetra blandit eros feugiat. Maecenas sed orci eget orci pharetra posuere id vel enim. Aenean ac lobortis lorem. Sed malesuada urna non consectetur condimentum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+## Second top-level
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sed sapien et sem scelerisque bibendum sed eget velit. Duis ut ultricies enim, vitae ultricies neque. Proin in purus eget orci posuere consequat sit amet ac augue. Aliquam dolor turpis, ultricies ac dui vel, maximus eleifend enim. Suspendisse eleifend orci non lectus mattis, pharetra blandit eros feugiat. Maecenas sed orci eget orci pharetra posuere id vel enim. Aenean ac lobortis lorem. Sed malesuada urna non consectetur condimentum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+### Second second-level
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sed sapien et sem scelerisque bibendum sed eget velit. Duis ut ultricies enim, vitae ultricies neque. Proin in purus eget orci posuere consequat sit amet ac augue. Aliquam dolor turpis, ultricies ac dui vel, maximus eleifend enim. Suspendisse eleifend orci non lectus mattis, pharetra blandit eros feugiat. Maecenas sed orci eget orci pharetra posuere id vel enim. Aenean ac lobortis lorem. Sed malesuada urna non consectetur condimentum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+## Third top-level
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sed sapien et sem scelerisque bibendum sed eget velit. Duis ut ultricies enim, vitae ultricies neque. Proin in purus eget orci posuere consequat sit amet ac augue. Aliquam dolor turpis, ultricies ac dui vel, maximus eleifend enim. Suspendisse eleifend orci non lectus mattis, pharetra blandit eros feugiat. Maecenas sed orci eget orci pharetra posuere id vel enim. Aenean ac lobortis lorem. Sed malesuada urna non consectetur condimentum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+### Third second-level
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sed sapien et sem scelerisque bibendum sed eget velit. Duis ut ultricies enim, vitae ultricies neque. Proin in purus eget orci posuere consequat sit amet ac augue. Aliquam dolor turpis, ultricies ac dui vel, maximus eleifend enim. Suspendisse eleifend orci non lectus mattis, pharetra blandit eros feugiat. Maecenas sed orci eget orci pharetra posuere id vel enim. Aenean ac lobortis lorem. Sed malesuada urna non consectetur condimentum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 pandas
+recommonmark


### PR DESCRIPTION
I was trying to figure out why markdown pages weren't showing TOC content in some of our docs, and I think it's because this theme is only picking up second-level markdown headings as "top-level" headings. So this adds a recommonmark page to the demo documentation and some short instructions about making it work.

The other option would be to try and fix the internal bug that prevents Sphinx from listing the single `#` headings, I think that fix would be here: https://github.com/pandas-dev/pandas-sphinx-theme/blob/master/pandas_sphinx_theme/__init__.py#L71 but I couldn't figure it out so a documentation improvement is a first step anyway :-)